### PR TITLE
Add a more permissible media completion

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,14 @@ This includes a list of major changes for each minor version starting from 0.19.
 For information on how to use `micom` please refer to
 [the documentation](https://micom-dev.github.io/micom).
 
+### 0.31.0
+
+The medium completion functions now have a flag that allows adding additional flux
+to components already in the candidate medium. The default is now changed to that
+new non-strict mode which makes it much easier and more efficient to complete media.
+In that case the `max_added_import` amount now specifies the maximum flux added on top
+the limit specified in the candidate medium.
+
 ### 0.30.5
 
 Fixed a bug where T-SNE would complain in low sample numbers.

--- a/micom/media.py
+++ b/micom/media.py
@@ -266,6 +266,7 @@ def complete_medium(
     max_import=1,
     minimize_components=False,
     weights=None,
+    strict=False,
 ):
     """Fill in missing components in a growth medium.
 
@@ -307,6 +308,13 @@ def complete_medium(
         the elemental content (for instance "C" to scale by carbon content).
         If None every metabolite will receive the same weight.
         Will be ignored if `minimize_components` is True.
+    strict : bool
+        Whether to match the imports in the predefined medium exactly. If True will
+        not allow additional import of the components in the provided medium. If False
+        additional import can be added but are kept as small as possible. For example
+        if your input medium has a flux of 10 mmol/(gDW*h) defined and the requested
+        growth rate can only be fulfilled by ramping this up that would be allowed in
+        non-strict mode but forbidden in strict mode.
 
 
     Returns
@@ -319,6 +327,7 @@ def complete_medium(
 
     """
     exids = [r.id for r in model.exchanges]
+    medium_rxns = [r for r in model.exchanges if r.id in medium.index]
     candidates = [r for r in model.exchanges if r.id not in medium.index]
     medium = medium[[i for i in medium.index if i in exids]]
     tol = model.solver.configuration.tolerances.feasibility
@@ -335,6 +344,17 @@ def complete_medium(
         model.add_cons_vars([const])
         model.objective = Zero
         model.medium = medium.to_dict()
+        extra_imports = []
+        if not strict:
+            for ex in medium_rxns:
+                ex_copy = ex.copy()
+                ex_copy.id = ex.id + "_free"
+                if hasattr(ex, "global_id"):
+                    ex_copy.global_id = ex.global_id + "_free"
+                    ex_copy.community_id = ex.community_id
+                extra_imports.append(ex_copy)
+                candidates.append(ex)
+            model.add_reactions(extra_imports)
         for ex in candidates:
             export = len(ex.reactants) == 1
             if export:
@@ -348,7 +368,8 @@ def complete_medium(
             add_linear_obj(model, candidates, scales)
         if isinstance(model, Community):
             sol = model.optimize(fluxes=True, pfba=False)
-            fluxes = sol.fluxes.loc["medium", :]
+            if sol is not None:
+                fluxes = sol.fluxes.loc["medium", :]
         else:
             try:
                 sol = model.optimize(raise_error=True)
@@ -362,13 +383,13 @@ def complete_medium(
     completed = pd.Series(dtype="float64")
     for rxn in model.exchanges:
         export = len(rxn.reactants) == 1
-        if rxn.id in medium.index:
-            completed[rxn.id] = medium[rxn.id]
-            continue
-        else:
-            flux = -fluxes[rxn.id] if export else fluxes[rxn.id]
+        flux = -fluxes[rxn.id] if export else fluxes[rxn.id]
         if abs(flux) < tol:
-            continue
+            flux = 0.0
         completed[rxn.id] = flux
+        if rxn in medium_rxns and not strict:
+            completed[rxn.id] += medium[rxn.id]
+        elif rxn in medium_rxns:
+            completed[rxn.id] = medium[rxn.id]
 
     return completed[completed > 0]

--- a/micom/workflows/__init__.py
+++ b/micom/workflows/__init__.py
@@ -5,13 +5,14 @@ from .build import build, build_database
 from .grow import grow
 from .tradeoff import tradeoff
 from .media import fix_medium, minimal_media
-from .db_media import check_db_medium
+from .db_media import check_db_medium, complete_db_medium
 
 __all__ = (
     "workflow",
     "build",
     "build_database",
     "check_db_medium",
+    "complete_db_medium",
     "grow",
     "tradeoff",
     "fix_medium",

--- a/micom/workflows/db_media.py
+++ b/micom/workflows/db_media.py
@@ -40,8 +40,13 @@ def _try_complete(args):
         exc = exc[2:]
     try:
         fixed = mm.complete_medium(
-            mod, med, growth, max_import=max_import, strict=strict,
-            minimize_components=mip, weights=w
+            mod,
+            med,
+            growth,
+            max_import=max_import,
+            strict=strict,
+            minimize_components=mip,
+            weights=w,
         )
         added = sum(i not in med.index for i in fixed.index)
         added_flux = fixed.sum() - med[med.index.isin(fixed.index)].sum()
@@ -193,8 +198,7 @@ def complete_db_medium(
     rank = manifest["summary_rank"][0]
     rprint(
         "Completing %d %s-level models on a medium with %d components"
-        " ([red]%d strict[/red])."
-        % (manifest.shape[0], rank, len(medium), len(strict))
+        " ([red]%d strict[/red])." % (manifest.shape[0], rank, len(medium), len(strict))
     )
     if not isinstance(growth, pd.Series):
         growth = pd.Series(growth, index=manifest.id)

--- a/micom/workflows/db_media.py
+++ b/micom/workflows/db_media.py
@@ -123,7 +123,7 @@ def complete_db_medium(
     minimize_components=False,
     weights=None,
     threads=1,
-    strict=False,
+    strict=list(),
 ):
     """Complete a growth medium for all models in a database.
 
@@ -158,13 +158,13 @@ def complete_db_medium(
     threads : int >=1
         The number of parallel workers to use when building models. As a
         rule of thumb you will need around 1GB of RAM for each thread.
-    strict : bool
-        Whether to match the imports in the predefined medium exactly. If True will
-        not allow additional import of the components in the provided medium. If False
-        additional import can be added but are kept as small as possible. For example
-        if your input medium has a flux of 10 mmol/(gDW*h) defined and the requested
-        growth rate can only be fulfilled by ramping this up that would be allowed in
-        non-strict mode but forbidden in strict mode.
+    strict : list
+        Whether to match the imports in the predefined medium exactly. For reactions IDs
+        listed here will not allow additional import of the components in the provided
+        medium. For example, if your input medium has a flux of 10 mmol/(gDW*h) defined
+        and the requested growth rate can only be fulfilled by ramping this up that
+        would be allowed in non-strict mode but forbidden in strict mode. To match all
+        medium components to strict mode use `strict=medium.global_id`.
 
     Returns
     -------

--- a/micom/workflows/db_media.py
+++ b/micom/workflows/db_media.py
@@ -32,14 +32,15 @@ def _grow(args):
 
 def _try_complete(args):
     """Try to complete the medium for a model."""
-    file, med, growth, max_import, mip, w = args
+    file, med, growth, max_import, mip, w, strict = args
     mod = load_model(file)
     exc = find_external_compartment(mod)
     if exc.startswith("C_"):  # for CARVEME models
         exc = exc[2:]
     try:
         fixed = mm.complete_medium(
-            mod, med, growth, max_import=max_import, minimize_components=mip, weights=w
+            mod, med, growth, max_import=max_import, strict=strict,
+            minimize_components=mip, weights=w
         )
         added = sum(i not in med.index for i in fixed.index)
         can_grow = True
@@ -156,6 +157,13 @@ def complete_db_medium(
     threads : int >=1
         The number of parallel workers to use when building models. As a
         rule of thumb you will need around 1GB of RAM for each thread.
+    strict : bool
+        Whether to match the imports in the predefined medium exactly. If True will
+        not allow additional import of the components in the provided medium. If False
+        additional import can be added but are kept as small as possible. For example
+        if your input medium has a flux of 10 mmol/(gDW*h) defined and the requested
+        growth rate can only be fulfilled by ramping this up that would be allowed in
+        non-strict mode but forbidden in strict mode.
 
     Returns
     -------
@@ -192,6 +200,7 @@ def complete_db_medium(
             max_added_import,
             minimize_components,
             weights,
+            strict,
         )
         for i in manifest.index
     ]

--- a/micom/workflows/db_media.py
+++ b/micom/workflows/db_media.py
@@ -123,6 +123,7 @@ def complete_db_medium(
     minimize_components=False,
     weights=None,
     threads=1,
+    strict=False,
 ):
     """Complete a growth medium for all models in a database.
 

--- a/tests/data/test_db_media.py
+++ b/tests/data/test_db_media.py
@@ -1,0 +1,53 @@
+"""Test media helpers for model databases."""
+
+import micom.data as md
+from micom.qiime_formats import load_qiime_medium
+from micom.workflows import complete_db_medium
+import pytest
+
+db = md.test_db
+medium = load_qiime_medium(md.test_medium)
+medium["global_id"] = medium["reaction"].replace("_m$", "_e", regex=True)
+
+
+def test_complete_strict():
+    pruned = medium.iloc[0:2]
+    manifest, fixed = complete_db_medium(
+        db,
+        growth=0.85,
+        medium=pruned,
+        strict=pruned.global_id,
+        max_added_import=20
+    )
+    assert fixed.shape[0] > 2
+    assert manifest.can_grow.all()
+    assert manifest.added.mean() > 0
+    assert manifest.added_flux.mean() > 1.0
+
+
+def test_complete_non_strict():
+    manifest, fixed = complete_db_medium(
+        db,
+        growth=0.95,
+        medium=medium,
+        max_added_import=20
+    )
+    assert fixed.shape[0] > 2
+    assert manifest.added.mean() > 0
+    assert manifest.added_flux.mean() > 1.0
+
+
+def test_complete_weighted():
+    pruned = medium.iloc[0:2]
+    manifest, fixed = complete_db_medium(
+        db,
+        growth=0.85,
+        medium=pruned,
+        strict=pruned.global_id,
+        max_added_import=20,
+        weights="mass"
+    )
+    assert fixed.shape[0] > 2
+    assert manifest.can_grow.all()
+    assert manifest.added.mean() > 0
+    assert manifest.added_flux.mean() > 1.0

--- a/tests/test_media.py
+++ b/tests/test_media.py
@@ -61,14 +61,16 @@ def test_medium_wrong_element(community):
 def test_complete_strict(community):
     m = media.minimal_medium(community, 0.85, 0.85,
                              minimize_components=False)
-    medium = media.complete_medium(community, m[0:2], 0.8, max_import=20, strict=True)
+    medium = media.complete_medium(community, m[0:2], 0.8, max_import=20,
+                                   strict=m.index)
     assert len(medium) > 2
 
 
 def test_complete_weights(community):
     m = media.minimal_medium(community, 0.85, 0.85,
                              minimize_components=False)
-    medium = media.complete_medium(community, m[0:2], 0.8, max_import=20, strict=True, weights="C")
+    medium = media.complete_medium(community, m[0:2], 0.8, max_import=20,
+                                   strict=m.index, weights="C")
     assert len(medium) == 4
 
 
@@ -76,7 +78,7 @@ def test_complete_non_strict(community):
     m = media.minimal_medium(community, 0.85, 0.85,
                              minimize_components=False)
     # request growth rates not fulfillable with previous bounds
-    medium = media.complete_medium(community, m, 0.95, 0.95, max_import=20, strict=False)
+    medium = media.complete_medium(community, m, 0.95, 0.95, max_import=20)
     community.medium = medium
     new_min = media.minimal_medium(community, 0.95, 0.95)
     assert len(medium) > 2
@@ -87,15 +89,15 @@ def test_complete_non_strict(community):
 def test_complete_mip_strict(community):
     m = media.minimal_medium(community, 0.85, 0.85,
                              minimize_components=True)
-    medium = media.complete_medium(community, m[0:2], 0.8, 0.8, max_import=20, strict=True,
-                                   minimize_components=True)
+    medium = media.complete_medium(community, m[0:2], 0.8, 0.8, max_import=20,
+                                   strict=m.index, minimize_components=True)
     assert len(medium) == 4
 
 
 def test_complete_mip_non_strict(community):
     m = media.minimal_medium(community, 0.85, 0.85,
                              minimize_components=True)
-    medium = media.complete_medium(community, m, 0.95, 0.95, max_import=20, strict=False,
+    medium = media.complete_medium(community, m, 0.95, 0.95, max_import=20,
                                    minimize_components=True)
     assert len(medium) == 5
 


### PR DESCRIPTION
The medium completion functions now have a flag that allows adding additional flux
to components already in the candidate medium. The default is now changed to that
new non-strict mode which makes it much easier and more efficient to complete media.
In that case the `max_added_import` amount now specifies the maximum flux added on top
the limit specified in the candidate medium.

```
In [1]: import micom as mm

In [2]: com = mm.Community(mm.data.test_taxonomy())
Building ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00

In [3]: med = mm.media.minimal_medium(com, 0.85, 0.85)

In [4]: med
Out[4]: 
EX_glc__D_m    10.000000
EX_nh4_m        4.634880
EX_o2_m        20.757401
EX_pi_m         3.126895
dtype: float64

In [5]: co = mm.media.complete_medium(com, growth=0.95, min_growth=0.95, medium=med, strict=med.index)  # old
[18:43:53] WARNING  solver encountered an error infeasible                                                                                                                              solution.py:220
---------------------------------------------------------------------------
OptimizationError                         Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 co = mm.media.complete_medium(com, growth=0.95, min_growth=0.95, medium=med, strict=med.index)

File ~/code/micom/micom/media.py:380, in complete_medium(model, medium, growth, min_growth, max_import, minimize_components, weights, strict)
    378             sol = None
    379 if sol is None:
--> 380     raise OptimizationError(
    381         "Could not find a solution that completes the medium :("
    382     )
    383 completed = pd.Series(dtype="float64")
    384 for rxn in model.exchanges:

OptimizationError: Could not find a solution that completes the medium :(

In [6]: co = mm.media.complete_medium(com, growth=0.95, min_growth=0.95, medium=med)  # new

In [7]: co
Out[7]: 
EX_fru_m        0.965127
EX_glc__D_m    11.000000
EX_gln__L_m     0.272640
EX_nh4_m        4.634880
EX_o2_m        20.757401
EX_pi_m         3.494765
dtype: float64

In [8]: co - med
Out[8]: 
EX_fru_m           NaN
EX_glc__D_m    1.00000
EX_gln__L_m        NaN
EX_nh4_m       0.00000
EX_o2_m        0.00000
EX_pi_m        0.36787
dtype: float64
```