### PR TITLE
Indicate tested comparison or covariate in test output

### DIFF
--- a/micom/duality.py
+++ b/micom/duality.py
@@ -62,7 +62,7 @@ def fast_dual(model, prefix="dual_"):
                 "Non-linear problems are not supported: " + str(constraint)
             )
         if constraint.lb is None and constraint.ub is None:
-            logger.warning("skipped free constraint %s" % constraint.name)
+            logger.debug("skipped free constraint %s" % constraint.name)
             continue  # Skip free constraint
         if constraint.lb == constraint.ub:
             const_var = prob.Variable(

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -66,6 +66,7 @@ def test_comparison_binary():
     assert "metabolite_3" in tests[tests.p > 0.01].metabolite.values
     assert "metabolite_4" in tests[tests.p > 0.01].metabolite.values
     assert "log_fold_change" in tests.columns
+    assert "comparison" in tests.columns
 
 
 def test_comparison_many():
@@ -76,6 +77,7 @@ def test_comparison_many():
     assert "metabolite_3" in tests[tests.p > 0.01].metabolite.values
     assert "metabolite_4" in tests[tests.p > 0.01].metabolite.values
     assert "log_mean_std" in tests.columns
+    assert "covariate" in tests.columns
 
 
 def test_correlation():
@@ -85,3 +87,5 @@ def test_correlation():
     assert "metabolite_2" in tests[tests.p < 0.01].metabolite.values
     assert "metabolite_3" in tests[tests.p > 0.01].metabolite.values
     assert "metabolite_4" in tests[tests.p > 0.01].metabolite.values
+    assert "covariate" in tests.columns
+    assert (tests.covariate == "time").all()


### PR DESCRIPTION
Before it was somewhat hard to figure out what specific comparison the log-fold changes and p-values corresponded to.